### PR TITLE
Issue #929: Fix striping on Layout block search form.

### DIFF
--- a/core/modules/layout/css/layout.admin.css
+++ b/core/modules/layout/css/layout.admin.css
@@ -53,6 +53,30 @@
 .layout-block-list {
   max-height: 300px;
   overflow: auto;
+  padding: 0 5px 0 0;
+}
+.layout-block-add-row.form-item {
+  padding:5px;
+  border-bottom: 1px solid #CCC;
+  margin: 0;
+}
+.layout-block-add-row.odd {
+  background-color: #F3F4EE;
+}
+.layout-block-list-wrapper {
+  border: 1px solid #CCC;
+}
+.layout-block-add-row.form-item {
+  padding: 5px;
+  border-bottom: 1px solid #CCC;
+  margin: 0;
+}
+.layout-block-add-row.odd {
+  background-color: #F3F4EE;
+}
+.layout-block-list-wrapper {
+  border: 1px solid #CCC;
+  border-bottom: none;
 }
 
 /* Layout editor. */

--- a/core/modules/layout/js/layout.admin.js
+++ b/core/modules/layout/js/layout.admin.js
@@ -110,5 +110,62 @@ Backdrop.behaviors.layoutDisplayEditor = {
   }
 };
 
+/**
+ * Filters the 'Add block' list by a text input search string.
+ */
+Backdrop.behaviors.blockListFilterByText = {
+  attach: function(context, settings) {
+    var $form = $('.layout-block-list', context).once('layout-block-list-search');
+    var $input = $('#layout-block-list-search', context);
+    var $rows, zebraClass;
+    var zebraCounter = 0;
+
+    // Fliter the list of layouts by provided search string.
+    function filterBlockList() {
+      var query = $input.val().toLowerCase();
+
+      function showBlockItem(index, row) {
+        var $row = $(row);
+        var $sources = $row.find('.block-item, .description');
+        var textMatch = $sources.text().toLowerCase().indexOf(query) !== -1;
+        var $match = $row.closest('div.layout-block-add-row');
+        $match.toggle(textMatch);
+        if (textMatch) {
+          stripeRow($match);
+        }
+      }
+
+      // Reset the zebra striping for consistent even/odd classes.
+      zebraCounter = 0;
+      $rows.each(showBlockItem);
+
+      if ($('div.layout-block-add-row:visible').length === 0) {
+        if ($('.filter-empty').length === 0) {
+          $('.layout-block-list').append('<p class="filter-empty">' + Backdrop.t('No blocks match your search.') + '</p>');
+        }
+      }
+      else {
+        $('.filter-empty').remove();
+      }
+    }
+    
+    function stripeRow($match) {
+      zebraClass = (zebraCounter % 2) ? 'odd' : 'even';
+      $match.removeClass('even odd');
+      $match.addClass(zebraClass);
+      zebraCounter++;
+    }
+
+    if ($form.length && $input.length) {
+      $rows = $form.find('div.layout-block-add-row');
+      $rows.each(function() {
+        stripeRow($(this));
+      });
+
+      // @todo Use autofocus attribute when possible.
+      $input.focus().on('keyup', filterBlockList);
+    }
+  }
+};
 
 })(jQuery);

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -900,24 +900,42 @@ function layout_block_add_page(Layout $layout, $renderer_name, $region_name, $bl
       }
     }
   }
-  ksort($block_list);
+  backdrop_sort($block_list, array('info' => SORT_STRING));
 
-  $output = array(
+  $output['search'] = array(
+    '#type' => 'textfield',
+    '#title' => 'Search',
+    '#attributes' => array(
+      'id' => array('layout-block-list-search'),
+    ),
+    // Hide the search if no JavaScript is available.
+    '#wrapper_attributes' => array(
+      'class' => array('js-show'),
+    ),
+  );
+  $output['block_list'] = array(
     '#type' => 'container',
     '#attributes' => array(
       'class' => array('layout-block-list'),
     ),
   );
 
+  $output['block_list']['block_list_inner'] = array(
+    '#type' => 'container',
+    '#attributes' => array(
+      'class' => array('layout-block-list-wrapper'),
+    ),
+  );
+
   foreach ($block_list as $key => $block_info) {
-    $output[$key] = array(
+    $output['block_list']['block_list_inner'][$key] = array(
       '#type' => 'item',
       '#markup' => l(
         $block_info['info'],
         'admin/structure/layouts/manage/' . $layout->name . '/add-block/' . $renderer_name . '/' . $region_name . '/' . $key,
         array(
           'attributes' => array(
-            'class' => array('use-ajax'),
+            'class' => array('use-ajax block-item'),
             'data-dialog' => TRUE,
             'data-dialog-options' => json_encode(array('dialogClass' => 'layout-dialog')),
           )


### PR DESCRIPTION
Hey @docwilmot, I saw @serundeputy file a PR against my sandbox yesterday. I didn't realize you could do that. I didn't get it quite right (as there are two commits instead of one because of the merge), but perhaps this would be a better way of suggesting changes.

This helps push forward https://github.com/backdrop/backdrop-issues/issues/929. Issues I found:
- When typing, the first row alternates between even and odd striping. This resets the striping to 0 every time for consistency.
- A few white-space issues.
- I found the 2 character requirement to be unnecessary and just calling .show() on all rows resulted in the striping not being corrected.
- If we add a right-only padding, we need a matching RTL left-only padding. When using an RTL language, the scroll bar is on the left instead of right side.
