### PR TITLE
Issue #2134: Converting context relationship functions into methods.

### DIFF
--- a/core/modules/dashboard/includes/dashboard_layout_context.inc
+++ b/core/modules/dashboard/includes/dashboard_layout_context.inc
@@ -4,6 +4,8 @@
  * Layout context handler for entities.
  */
 class DashboardLayoutContext extends LayoutContext {
+  var $usageType = LayoutContext::USAGE_TYPE_SYSTEM;
+
   /**
    * Return the indicator for this context.
    */

--- a/core/modules/layout/includes/block.class.inc
+++ b/core/modules/layout/includes/block.class.inc
@@ -221,11 +221,9 @@ class Block extends LayoutHandler {
    * Build the settings form for editing this block.
    */
   function form(&$form, &$form_state) {
+    /* @var Layout $layout */
     $layout = $form_state['layout'];
-    $contexts = $layout->getContexts();
-
-    // Get contexts from relationships
-    layout_get_context_from_relationships($layout->relationships, $contexts);
+    $contexts = $layout->getAllContexts();
 
     $block_info = $this->getBlockInfo();
     $current_context_settings = isset($this->settings['contexts']) ? $this->settings['contexts'] : array();

--- a/core/modules/layout/includes/block.class.inc
+++ b/core/modules/layout/includes/block.class.inc
@@ -223,7 +223,7 @@ class Block extends LayoutHandler {
   function form(&$form, &$form_state) {
     /* @var Layout $layout */
     $layout = $form_state['layout'];
-    $contexts = $layout->getAllContexts();
+    $contexts = $layout->getContexts();
 
     $block_info = $this->getBlockInfo();
     $current_context_settings = isset($this->settings['contexts']) ? $this->settings['contexts'] : array();

--- a/core/modules/layout/includes/layout.class.inc
+++ b/core/modules/layout/includes/layout.class.inc
@@ -55,7 +55,7 @@ class Layout {
    *
    * This represents whether this layout is has a default, user-created, or
    * overridden configuration. Possible values for this variable include the
-   * constants LAYOUT_STORAGE_NORMAL, LAYOUT_STORAGE_OVERRIDE, or 
+   * constants LAYOUT_STORAGE_NORMAL, LAYOUT_STORAGE_OVERRIDE, or
    * LAYOUT_STORAGE_DEFAULT.
    *
    * @var int
@@ -773,9 +773,25 @@ class Layout {
   /**
    * Return all contexts (from both the layout and menu item) for this Layout.
    *
-   * return LayoutContext[]
+   * @var int $include_types
+   *   Include a specific list of contexts based on how they are used.
+   *
+   *   This is loaded from the list of constants provided in the
+   *   LayoutContext class, which includes the following:
+   *
+   *   - USAGE_TYPE_ALL - All contexts from all possible sources.
+   *   - USAGE_TYPE_DEFAULT - All contexts except those from relationships.
+   *   - USAGE_TYPE_CUSTOM - Contexts manually specified in configuration.
+   *   - USAGE_TYPE_MENU - Contexts automatically provided from a menu path.
+   *   - USAGE_TYPE_SYSTEM - Global contexts such as logged-in user.
+   *   - USAGE_TYPE_RELATIONSHIP - Contexts added through relationships.
+   *
+   * @return LayoutContext[]
+   *
+   * @see Layout::getAllContexts()
    */
-  function getContexts() {
+  function getContexts($include_types = LayoutContext::USAGE_TYPE_DEFAULT) {
+    // Initialize a list of contexts if not defined.
     if (is_null($this->contexts)) {
       $this->contexts = array();
     }
@@ -799,6 +815,11 @@ class Layout {
       $this->contexts += layout_context_required_by_path($this->path);
     }
 
+    // Load contexts from relationships.
+    if ($include_types & LayoutContext::USAGE_TYPE_RELATIONSHIP) {
+      $this->contexts += $this->getContextsFromRelationships();
+    }
+
     // Add on the current user context, which is always available.
     if (!isset($this->contexts['current_user'])) {
       $this->contexts['current_user'] = layout_current_user_context();
@@ -812,7 +833,24 @@ class Layout {
       ));
     }
 
-    return $this->contexts;
+    // Trim down the list of contexts to only those requested.
+    $return_contexts = array();
+    foreach ($this->contexts as $key => $context) {
+      if ($context->usageType & $include_types) {
+        $return_contexts[$key] = $context;
+      }
+    }
+
+    return $return_contexts;
+  }
+
+  /**
+   * Shortcut to Layout::getContexts() that loads all possible contexts.
+   *
+   * @return LayoutContext[]
+   */
+  function getAllContexts() {
+    return $this->getContexts(LayoutContext::USAGE_TYPE_ALL);
   }
 
   /**
@@ -855,8 +893,7 @@ class Layout {
    *   TRUE if this layout has all the required contexts, FALSE otherwise.
    */
   function hasContexts($required_contexts) {
-    $all_contexts = $this->getContexts();
-    layout_get_context_from_relationships($this->relationships, $all_contexts);
+    $all_contexts = $this->getAllContexts();
     foreach ($required_contexts as $required_context_name) {
       $context_missing = TRUE;
       foreach ($all_contexts as $context) {
@@ -872,6 +909,56 @@ class Layout {
     }
 
     return TRUE;
+  }
+
+  /**
+   * @param LayoutRelationship $relationship
+   *   A relationship object.
+   *
+   * @param LayoutContext $source_context
+   *   The context this relationship is based upon.
+   *
+   * @return LayoutContext|FALSE
+   *   A context object if one can be loaded.
+   */
+  private function getContextFromRelationship(LayoutRelationship $relationship, LayoutContext $source_context) {
+    $new_context = clone($source_context);
+    $context = $relationship->getContext($new_context);
+    if ($context) {
+      $context->usageType = LayoutContext::USAGE_TYPE_RELATIONSHIP;
+      return $context;
+    }
+    return FALSE;
+  }
+
+  /**
+   * Load the contexts based on this Layout's relationship configuration.
+   */
+  private function getContextsFromRelationships() {
+    $contexts = array();
+    $contexts_from_relationships_list = array();
+    foreach ($this->relationships as $relationship_name => $relationship_data) {
+      $key = 'relationship_' . $relationship_name;
+      if (!isset($contexts_from_relationships_list[$key])) {
+        foreach ($this->contexts as $context) {
+          if ($context->plugin == $relationship_data->context) {
+            $plugin_array = explode(':', $relationship_data->settings['relationship']);
+            if ($plugin_array[1] != 'child') {
+              $relationship_data->childDelta = $plugin_array[1];
+            }
+            $contexts_from_relationships_list[$key] = $this->getContextFromRelationship($relationship_data, $context);
+          }
+        }
+      }
+    }
+    if ($contexts_from_relationships_list) {
+      foreach ($contexts_from_relationships_list as $key => $context_from_relationships) {
+        if (is_object($context_from_relationships)) {
+          $contexts[$key] = $context_from_relationships;
+        }
+      }
+    }
+    return $contexts;
   }
 
   /**

--- a/core/modules/layout/includes/layout.class.inc
+++ b/core/modules/layout/includes/layout.class.inc
@@ -780,17 +780,14 @@ class Layout {
    *   LayoutContext class, which includes the following:
    *
    *   - USAGE_TYPE_ALL - All contexts from all possible sources.
-   *   - USAGE_TYPE_DEFAULT - All contexts except those from relationships.
    *   - USAGE_TYPE_CUSTOM - Contexts manually specified in configuration.
    *   - USAGE_TYPE_MENU - Contexts automatically provided from a menu path.
    *   - USAGE_TYPE_SYSTEM - Global contexts such as logged-in user.
    *   - USAGE_TYPE_RELATIONSHIP - Contexts added through relationships.
    *
    * @return LayoutContext[]
-   *
-   * @see Layout::getAllContexts()
    */
-  function getContexts($include_types = LayoutContext::USAGE_TYPE_DEFAULT) {
+  function getContexts($include_types = LayoutContext::USAGE_TYPE_ALL) {
     // Initialize a list of contexts if not defined.
     if (is_null($this->contexts)) {
       $this->contexts = array();
@@ -833,7 +830,12 @@ class Layout {
       ));
     }
 
-    // Trim down the list of contexts to only those requested.
+    // Return all contexts if requested.
+    if ($include_types === LayoutContext::USAGE_TYPE_ALL) {
+      return $this->contexts;
+    }
+
+    // Otherwise filter down the list of contexts to only those requested.
     $return_contexts = array();
     foreach ($this->contexts as $key => $context) {
       if ($context->usageType & $include_types) {
@@ -842,15 +844,6 @@ class Layout {
     }
 
     return $return_contexts;
-  }
-
-  /**
-   * Shortcut to Layout::getContexts() that loads all possible contexts.
-   *
-   * @return LayoutContext[]
-   */
-  function getAllContexts() {
-    return $this->getContexts(LayoutContext::USAGE_TYPE_ALL);
   }
 
   /**
@@ -893,7 +886,7 @@ class Layout {
    *   TRUE if this layout has all the required contexts, FALSE otherwise.
    */
   function hasContexts($required_contexts) {
-    $all_contexts = $this->getAllContexts();
+    $all_contexts = $this->getContexts();
     foreach ($required_contexts as $required_context_name) {
       $context_missing = TRUE;
       foreach ($all_contexts as $context) {

--- a/core/modules/layout/includes/layout.layout.inc
+++ b/core/modules/layout/includes/layout.layout.inc
@@ -80,9 +80,9 @@ function layout_layout_context_info() {
  * Implements hook_layout_relationship_info().
  */
 function layout_layout_relationship_info() {
-  $info['user_from_node'] = array(
+  $info['author_from_node'] = array(
     'title' => t('User from node'),
-    'class' => 'LayoutRelationshipUserFromNode',
+    'class' => 'LayoutRelationshipAuthorFromNode',
     'context' => 'node',
     'context_label' => t('Node'),
     'description' => t('Creates the author of a node as a user context.'),

--- a/core/modules/layout/includes/layout.layout.inc
+++ b/core/modules/layout/includes/layout.layout.inc
@@ -81,7 +81,7 @@ function layout_layout_context_info() {
  */
 function layout_layout_relationship_info() {
   $info['author_from_node'] = array(
-    'title' => t('User from node'),
+    'title' => t('Author from content'),
     'class' => 'LayoutRelationshipAuthorFromNode',
     'context' => 'node',
     'context_label' => t('Node'),

--- a/core/modules/layout/includes/layout_menu_item.class.inc
+++ b/core/modules/layout/includes/layout_menu_item.class.inc
@@ -247,7 +247,10 @@ class LayoutMenuItem {
     // Add in configured arguments.
     foreach ($this->arguments as $position => $argument_config) {
       if (isset($path_parts[$position]) && $path_parts[$position] === '%') {
-        $context_config = $argument_config + array('required' => TRUE);
+        $context_config = $argument_config + array(
+          'required' => TRUE,
+          'usageType' => LayoutContext::USAGE_TYPE_MENU,
+        );
         $contexts[$position] = layout_create_context($argument_config['plugin'], $context_config);
       }
     }

--- a/core/modules/layout/layout.admin.inc
+++ b/core/modules/layout/layout.admin.inc
@@ -311,7 +311,8 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
     '#access' => !$layout->isDefault(),
   );
 
-  $contexts = $layout->getContexts();
+  // Get all contexts except those provided by relationships.
+  $contexts = $layout->getContexts(LayoutContext::USAGE_TYPE_ALL ^ LayoutContext::USAGE_TYPE_RELATIONSHIP);
   $built_in_contexts = isset($contexts['overrides_path']) ? 2 : 1;
   $form['context_wrapper'] = array(
     '#title' => t('Contexts'),
@@ -379,7 +380,7 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
   );
 
   foreach ($contexts as $context_key => $layout_context) {
-    if (!in_array($context_key, array('current_user', 'overrides_path', 'dashboard'))) {
+    if ($layout_context->usageType !== LayoutContext::USAGE_TYPE_SYSTEM) {
       // Contexts that are locked to a particular position (such as node/%).
       if ($layout_context->position && $layout_context->required) {
         $form['context_wrapper']['context']['required'][$context_key]['summary'] = array(
@@ -445,13 +446,16 @@ function layout_settings_form($form, &$form_state, Layout $layout) {
       }
     }
   }
+
   $all_relationship_info = _layout_get_all_info('layout_relationship');
   foreach ($layout->relationships as $relationship_key => $relationship) {
     $form['context_wrapper']['context']['required'][$relationship_key]['summary'] = array(
       '#markup' => $relationship->getAdminSummary(),
     );
     $form['context_wrapper']['context']['required'][$relationship_key]['plugin'] = array(
-      '#markup' => check_plain($all_relationship_info[$relationship->plugin]['title']),
+      '#markup' => isset($all_relationship_info[$relationship->plugin]['title']) ?
+        check_plain($all_relationship_info[$relationship->plugin]['title']) :
+        t('Broken'),
     );
     $form['context_wrapper']['context']['required'][$relationship_key]['operations'] = array(
       '#type' => 'container',

--- a/core/modules/layout/layout.module
+++ b/core/modules/layout/layout.module
@@ -865,7 +865,7 @@ function layout_autoload_info() {
     'LayoutStyleDynamic' => 'plugins/styles/layout_style_dynamic.inc',
 
     // Relationships.
-    'LayoutRelationshipUserFromNode' => 'plugins/relationships/user_from_node.inc',
+    'LayoutRelationshipAuthorFromNode' => 'plugins/relationships/author_from_node.inc',
     'LayoutRelationship' => 'plugins/relationships/layout_relationship.inc',
     'LayoutRelationshipBroken' => 'plugins/relationships/layout_relationship.inc',
   );
@@ -1260,10 +1260,10 @@ function layout_get_layout_by_path($path = NULL, $router_item = NULL) {
     }
     $selected_layout = NULL;
     foreach ($layouts as $layout) {
-      // Contexts must be set before the layout's access may be checked.
-      $contexts = $layout->getContexts();
+      // Set context data from the menu path.
+      $menu_contexts = $layout->getContexts(LayoutContext::USAGE_TYPE_MENU);
 
-      foreach ($contexts as $context) {
+      foreach ($menu_contexts as $context) {
         if (isset($context->position)) {
 
           // Check for an object loaded by the menu router. Use a preview from
@@ -1284,13 +1284,6 @@ function layout_get_layout_by_path($path = NULL, $router_item = NULL) {
             }
           }
         }
-      }
-
-      // Get contexts from relationships
-      $relationships = $layout->relationships;
-      layout_get_context_from_relationships($relationships, $contexts);
-      foreach ($contexts as $key => $context) {
-        $layout->setContexts($key, $context);
       }
 
       if (!$layout->disabled && $layout->checkAccess()) {
@@ -1540,61 +1533,6 @@ function layout_relationships_get_relevant_info($contexts) {
   }
 
   return $relevant;
-}
-
-
-/**
- * @param $relationship
- *   A relationship object.
- *
- * @param $source_context
- *   The context this relationship is based upon.
- *
- * @return
- *   A context object if one can be loaded.
- */
-function layout_get_context_from_relationship($relationship, $source_context) {
-  $new_context = clone($source_context);
-  $context = $relationship->getContext($new_context);
-  if ($context) {
-    return $context;
-  }
-  return array();
-}
-
-/**
- * Fetch all active relationships
- *
- * @param $relationships
- *   An keyed array of relationship objects.
- *
- * @param $contexts
- *   A keyed array of contexts used to figure out which relationships
- *   are relevant. New contexts will be added to this.
- */
-function layout_get_context_from_relationships($relationships, &$contexts) {
-  $contexts_from_relationships_list  = &backdrop_static('layout_get_context_from_relationships', array());
-  foreach ($relationships as $rname => $rdata) {
-    $key = 'relationship_' . $rname;
-    if (!isset($contexts_from_relationships_list[$key])) {
-      foreach ($contexts as $context) {
-        if ($context->plugin == $rdata->context) {
-          $plugin_array = explode(':', $rdata->settings['relationship']);
-          if ($plugin_array[1] != 'child') {
-            $rdata->childDelta = $plugin_array[1];
-          }
-          $contexts_from_relationships_list[$key] = layout_get_context_from_relationship($rdata, $context);
-        }
-      }
-    }
-  }
-  if ($contexts_from_relationships_list) {
-    foreach ($contexts_from_relationships_list as $key => $context_from_relationships) {
-      if (is_object($context_from_relationships)) {
-        $contexts[$key] = $context_from_relationships;
-      }
-    }
-  }
 }
 
 /**
@@ -1950,6 +1888,7 @@ function layout_context_required_by_path($path) {
   foreach ($required_context_info as $context_position => $context_info) {
     $context = layout_create_context($context_info['plugin']);
     $context->required = TRUE;
+    $context->usageType = LayoutContext::USAGE_TYPE_MENU;
     // String placeholders are not locked, allowing a new value to be set.
     $context->locked = $context_info['plugin'] !== 'string';
     $context->position = $context_position;
@@ -1973,6 +1912,7 @@ function layout_current_user_context() {
     'name' => 'current_user',
     'label' => t('Current user'),
     'locked' => TRUE,
+    'usageType' => LayoutContext::USAGE_TYPE_SYSTEM,
   ));
   $current_user_context->setData($GLOBALS['user']);
   return $current_user_context;

--- a/core/modules/layout/plugins/access/layout_access.inc
+++ b/core/modules/layout/plugins/access/layout_access.inc
@@ -64,14 +64,12 @@ class LayoutAccess extends LayoutHandler {
     /* @var Layout|LayoutMenuItem $item */
     if ($form_state['menu_item']) {
       $item = $form_state['menu_item'];
-      $contexts = $item->getContexts();
     }
     else {
       $item = $form_state['layout'];
-      $contexts = $item->getAllContexts();
     }
     $access_info = layout_get_access_info($this->plugin);
-
+    $contexts = $item->getContexts();
     $current_context_settings = isset($this->settings['contexts']) ? $this->settings['contexts'] : array();
     $form['contexts'] = layout_contexts_form_element($contexts, $current_context_settings, $access_info);
   }

--- a/core/modules/layout/plugins/access/layout_access.inc
+++ b/core/modules/layout/plugins/access/layout_access.inc
@@ -68,10 +68,7 @@ class LayoutAccess extends LayoutHandler {
     }
     else {
       $item = $form_state['layout'];
-      $contexts = $item->getContexts();
-
-      // Get contexts from relationships
-      layout_get_context_from_relationships($item->relationships, $contexts);
+      $contexts = $item->getAllContexts();
     }
     $access_info = layout_get_access_info($this->plugin);
 

--- a/core/modules/layout/plugins/context/layout_context.inc
+++ b/core/modules/layout/plugins/context/layout_context.inc
@@ -29,14 +29,9 @@ abstract class LayoutContext extends LayoutHandler {
   const USAGE_TYPE_RELATIONSHIP = 8;
 
   /**
-   * The default list of context types when calling Layout::getContexts().
+   * All possible context types.
    */
-  const USAGE_TYPE_DEFAULT = self::USAGE_TYPE_CUSTOM | self::USAGE_TYPE_MENU | self::USAGE_TYPE_SYSTEM;
-
-  /**
-   * All possible context types, including relationships.
-   */
-  const USAGE_TYPE_ALL = self::USAGE_TYPE_DEFAULT | self::USAGE_TYPE_RELATIONSHIP;
+  const USAGE_TYPE_ALL = self::USAGE_TYPE_CUSTOM | self::USAGE_TYPE_MENU | self::USAGE_TYPE_SYSTEM | self::USAGE_TYPE_RELATIONSHIP;
 
   /**
    * The name of the plugin that provides this context.

--- a/core/modules/layout/plugins/context/layout_context.inc
+++ b/core/modules/layout/plugins/context/layout_context.inc
@@ -30,8 +30,17 @@ abstract class LayoutContext extends LayoutHandler {
 
   /**
    * All possible context types.
+   *
+   * This is equivalent to the following bitwise addition of all the above:
+   *
+   * @code
+   *   self::USAGE_TYPE_CUSTOM | self::USAGE_TYPE_MENU | self::USAGE_TYPE_SYSTEM | self::USAGE_TYPE_RELATIONSHIP
+   * @endcode
+   *
+   * PHP 5.6 and higher is required to do this math in a constant however, so
+   * it is defined here as the equivalent integer value.
    */
-  const USAGE_TYPE_ALL = self::USAGE_TYPE_CUSTOM | self::USAGE_TYPE_MENU | self::USAGE_TYPE_SYSTEM | self::USAGE_TYPE_RELATIONSHIP;
+  const USAGE_TYPE_ALL = 15;
 
   /**
    * The name of the plugin that provides this context.

--- a/core/modules/layout/plugins/context/layout_context.inc
+++ b/core/modules/layout/plugins/context/layout_context.inc
@@ -5,6 +5,39 @@
  * Class that holds information relating to a layouts context.
  */
 abstract class LayoutContext extends LayoutHandler {
+
+  /**
+   * Declares a LayoutContext to be a manually specified custom context.
+   */
+  const USAGE_TYPE_CUSTOM = 1;
+
+  /**
+   * Declares a LayoutContext to be provided based on a menu item or path.
+   */
+  const USAGE_TYPE_MENU = 2;
+
+  /**
+   * Declares a LayoutContext to be a system-wide context
+   *
+   * Examples include the "current_user" context and "overrides_path" context.
+   */
+  const USAGE_TYPE_SYSTEM = 4;
+
+  /**
+   * Declares a LayoutContext is provided by a relationship to another context.
+   */
+  const USAGE_TYPE_RELATIONSHIP = 8;
+
+  /**
+   * The default list of context types when calling Layout::getContexts().
+   */
+  const USAGE_TYPE_DEFAULT = self::USAGE_TYPE_CUSTOM | self::USAGE_TYPE_MENU | self::USAGE_TYPE_SYSTEM;
+
+  /**
+   * All possible context types, including relationships.
+   */
+  const USAGE_TYPE_ALL = self::USAGE_TYPE_DEFAULT | self::USAGE_TYPE_RELATIONSHIP;
+
   /**
    * The name of the plugin that provides this context.
    *
@@ -111,6 +144,27 @@ abstract class LayoutContext extends LayoutHandler {
   var $storage = FALSE;
 
   /**
+   * Declares how this context is used by a Layout.
+   *
+   * For example a "user" context might be available in a Layout through
+   * multiple sources. If the layout overrides the path "user/%" one user
+   * context would have the $usageType LayoutContext::USAGE_TYPE_MENU.
+   *
+   * If the author of a node is added to a Layout through a relationship,
+   * a second context would be available with the $usageType
+   * LayoutContext::USAGE_TYPE_RELATIONSHIP.
+   *
+   * Checking a context's $usageType can help determine where and how a context
+   * was added to a Layout object.
+   *
+   * This value must be one of the USAGE_TYPE_* constants defined in the
+   * LayoutContext class.
+   *
+   * @var int
+   */
+  var $usageType = self::USAGE_TYPE_CUSTOM;
+
+  /**
    * Constructor for LayoutContext objects.
    */
   function __construct($plugin_name, $config = array()) {
@@ -123,6 +177,7 @@ abstract class LayoutContext extends LayoutHandler {
       'name',
       'label',
       'storage',
+      'usageType',
     );
     foreach ($properties as $property) {
       if (isset($config[$property])) {
@@ -228,6 +283,7 @@ class LayoutContextBroken extends LayoutContext {
  * Pass-through context used when an unknown argument is encountered.
  */
 class LayoutOverridesPathContext extends LayoutContext {
+  var $usageType = LayoutContext::USAGE_TYPE_SYSTEM;
   function type() {
     return 'overrides_path';
   }

--- a/core/modules/layout/plugins/relationships/author_from_node.inc
+++ b/core/modules/layout/plugins/relationships/author_from_node.inc
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Class that holds information relating to the user from node relationship.
+ * Provides relationship to relate the Author from a piece of content (node).
  */
 class LayoutRelationshipAuthorFromNode extends LayoutRelationship {
   /**
@@ -37,13 +37,13 @@ class LayoutRelationshipAuthorFromNode extends LayoutRelationship {
     if (!empty($this->settings['context_parent'])) {
       list($label, $value) = explode(':', $this->settings['context_parent']);
       if ($label == 'position') {
-        return t('User from node in position @position', array('@position' => $value+1));
+        return t('Author from content in position @position', array('@position' => $value+1));
       }
       else {
-        return t('User from node @id', array('@id' => $value));
+        return t('Author from content @id', array('@id' => $value));
       }
     }
-    return t('User from node');
+    return t('Author from content');
   }
 
 }

--- a/core/modules/layout/plugins/relationships/author_from_node.inc
+++ b/core/modules/layout/plugins/relationships/author_from_node.inc
@@ -4,19 +4,25 @@
  * @file
  * Class that holds information relating to the user from node relationship.
  */
-class LayoutRelationshipUserFromNode extends LayoutRelationship {
+class LayoutRelationshipAuthorFromNode extends LayoutRelationship {
   /**
    * Get the context from this relationship.
+   *
+   * @param LayoutContext $source_context;
+   *   The source context on which this relationship is based.
+   *
+   * @return LayoutContext|FALSE
+   *   The additional context added once this relationship is joined.
    */
-  function getContext($context) {
+  function getContext(LayoutContext $source_context) {
     $account = NULL;
-    if (isset($context->data->uid)) {
+    if (isset($source_context->data->uid)) {
       // Load the user that is the author of the node.
-      $uid = $context->data->uid;
+      $uid = $source_context->data->uid;
       $account = user_load($uid);
     }
     $user_context = layout_create_context('user', array(
-      'position' => $context->position,
+      'position' => $source_context->position,
       'label' => $this->getAdminSummary(),
     ));
     $user_context->setData($account);

--- a/core/modules/layout/plugins/relationships/layout_relationship.inc
+++ b/core/modules/layout/plugins/relationships/layout_relationship.inc
@@ -4,7 +4,7 @@
  * @file
  * Class that holds information relating to a layout's context relationships.
  */
-abstract class LayoutRelationship extends LayoutHandler{
+abstract class LayoutRelationship extends LayoutHandler {
   /**
    * The name of the plugin that provides this relationship.
    *
@@ -62,6 +62,17 @@ abstract class LayoutRelationship extends LayoutHandler{
       $this->childDelta = ($child == 'relationship') ? NULL : $child;
     }
   }
+
+  /**
+   * Get the context from this relationship.
+   *
+   * @param LayoutContext $source_context;
+   *   The source context on which this relationship is based.
+   *
+   * @return LayoutContext|FALSE
+   *   The additional context added once this relationship is joined.
+   */
+  abstract function getContext(LayoutContext $source_context);
 
   /**
    * Assemble a human-readable label of this object.
@@ -166,6 +177,10 @@ abstract class LayoutRelationship extends LayoutHandler{
  * A class to be used for relationships whose handler cannot be found.
  */
 class LayoutRelationshipBroken extends LayoutRelationship {
+  function getContext(LayoutContext $source_context) {
+    return FALSE;
+  }
+
   function type() {
     return 'broken';
   }

--- a/core/modules/layout/plugins/relationships/layout_relationship.inc
+++ b/core/modules/layout/plugins/relationships/layout_relationship.inc
@@ -180,7 +180,9 @@ class LayoutRelationshipBroken extends LayoutRelationship {
   function getContext(LayoutContext $source_context) {
     return FALSE;
   }
-
+  function getAdminSummary() {
+    return '<em>' . t('Missing relationship: @plugin', array('@plugin' => $this->plugin)) . '</em>';
+  }
   function type() {
     return 'broken';
   }

--- a/core/modules/layout/plugins/renderers/layout_renderer_standard.inc
+++ b/core/modules/layout/plugins/renderers/layout_renderer_standard.inc
@@ -210,9 +210,8 @@ class LayoutRendererStandard {
       // Check access on each block.
       if (empty($this->admin)) {
         // Assign contexts to each block.
-        $layout_contexts = $this->layout->getContexts();
-        
-        layout_get_context_from_relationships($this->layout->relationships, $layout_contexts);
+        $layout_contexts = $this->layout->getAllContexts();
+
         $has_contexts = TRUE;
         $required_contexts = $block->getRequiredContexts();
         if ($required_contexts) {

--- a/core/modules/layout/plugins/renderers/layout_renderer_standard.inc
+++ b/core/modules/layout/plugins/renderers/layout_renderer_standard.inc
@@ -210,7 +210,7 @@ class LayoutRendererStandard {
       // Check access on each block.
       if (empty($this->admin)) {
         // Assign contexts to each block.
-        $layout_contexts = $this->layout->getAllContexts();
+        $layout_contexts = $this->layout->getContexts();
 
         $has_contexts = TRUE;
         $required_contexts = $block->getRequiredContexts();

--- a/core/modules/layout/tests/layout.test
+++ b/core/modules/layout/tests/layout.test
@@ -70,7 +70,7 @@ class LayoutInterfaceTest extends BackdropWebTestCase {
     // Check the path first to populate available contexts.
     $this->backdropPost('admin/structure/layouts/add', $edit, t('Check path'));
 
-     // Test user from node relationship.
+     // Test Author from Content relationship.
     $edit = array();
     $this->backdropPost('admin/structure/layouts/manage/' . $layout_name . '/configure', $edit, t('Add context relationship'));
 

--- a/core/modules/layout/tests/layout.test
+++ b/core/modules/layout/tests/layout.test
@@ -75,7 +75,7 @@ class LayoutInterfaceTest extends BackdropWebTestCase {
     $this->backdropPost('admin/structure/layouts/manage/' . $layout_name . '/configure', $edit, t('Add context relationship'));
 
     $edit = array(
-      'relationship' => 'user_from_node:relationship',
+      'relationship' => 'author_from_node:relationship',
     );
     $this->backdropPost(NULL, $edit, t('Load relationship'));
     $this->backdropPost(NULL, array(), t('Add relationship'));
@@ -131,7 +131,7 @@ class LayoutInterfaceTest extends BackdropWebTestCase {
     $this->backdropGet('node/' . $this->test_node1->nid);
     $this->assertText(format_string('The user name is @name and the node title is @title', array('@name' => $this->admin_user->name, '@title' => $this->test_node1->title)));
 
-     // Remove the user from node relationship.
+     // Remove the author from node relationship.
     $this->backdropPost('admin/structure/layouts/manage/' . $layout_name . '/configure', array(), t('Remove'));
   }
 

--- a/core/modules/layout/tests/layout.test
+++ b/core/modules/layout/tests/layout.test
@@ -90,8 +90,8 @@ class LayoutInterfaceTest extends BackdropWebTestCase {
       ':select' => 'edit-contexts-my-user',
     ));
     $this->assertEqual(count($select_options), 2, 'Two options are found in the select list.');
-    $relationship_option = (string) $select_options[1]['value'];
-    $this->assertTrue(strpos($relationship_option, 'relationship') === 0);
+    $relationship_option = (string) $select_options[0]['value'];
+    $this->assertTrue(strpos($relationship_option, 'relationship') === 0, 'First select list option is the user context from the author relationship.');
 
     $edit = array(
       'contexts[my_user]' => $relationship_option,


### PR DESCRIPTION
Builds on https://github.com/backdrop/backdrop/pull/3422 by doing the following:

- Renames "user_from_node" relationship plugin to "author_from_node"
- Moves logic from `layout_get_context_from_relationships()` to a private method `Layout::getContextFromRelationships()`
- Builds in loading of context relationships directly into `Layout::getContexts()` so that relationships do not need to be loaded separately. They can just be requested to be loaded at the same time as all other relationships.

Making this last change required that we be able to differentiate between contexts that are added through relationships versus other mechanisms. This has been a problem with contexts from the beginning: You can't really tell where the context came from other than by a loose naming convention on the array keys (i.e. a integer comes from a menu path, "current_user" is always specially keyed, and now prefixing with "relationship_"). The way the context is added is now explicitly set in `LayoutContext::usageType`, a public property on the `LayoutContext` class.